### PR TITLE
 [FINAL] Adding settings file to prefer line-comments rather than block-comments.

### DIFF
--- a/settings/language-squirrel.cson
+++ b/settings/language-squirrel.cson
@@ -1,0 +1,4 @@
+'.source.nut':
+  'editor':
+    'commentStart': '// '
+    


### PR DESCRIPTION
Added `settings/language-squirrel.cson` with an entry to specify that the editor should default to line-comments (`//`) rather than block-comments (`/* */`). :floppy_disk: :bowtie:  This matches the way comments seem to work in most other languages I've seen in Atom. :deciduous_tree: 
